### PR TITLE
Fix dependsOn for CAPI + update schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix App dependency for CAPI.
+- Update helm values validation schema.
+
 ## [0.7.1] - 2023-12-15
 
 ### Changed

--- a/helm/service-mesh-bundle/templates/apps.yaml
+++ b/helm/service-mesh-bundle/templates/apps.yaml
@@ -1,13 +1,17 @@
-{{- range $key, $value := .Values.apps }}
+{{- range .Values.apps }}
 {{- $appName := include "app.name" (dict "app" .appName "cluster" $.Values.clusterID "ns" $.Release.Namespace) }}
 {{- if .enabled }}
+{{- $annotations := .annotations | default dict }}
+{{- if .dependsOn -}}
+{{- $annotations := merge $annotations (dict "app-operator.giantswarm.io/depends-on" (include "app.name" (dict "app" .dependsOn "cluster" $.Values.clusterID "ns" $.Release.Namespace))) }}
+{{- end }}
 ---
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
   labels:
     {{- include "labels.common" $ | nindent 4 }}
-  {{- with .annotations }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +28,7 @@ spec:
   install:
     skipCRDs: {{.skipCRDs | default false }}
     timeout: 10m
-  upgrade: 
+  upgrade:
     timeout: 10m
   kubeConfig:
     inCluster: false

--- a/helm/service-mesh-bundle/templates/apps.yaml
+++ b/helm/service-mesh-bundle/templates/apps.yaml
@@ -39,12 +39,17 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   version: {{ .version }}
-  {{- if .extraConfigs }}
+  {{- with .extraConfigs }}
   extraConfigs:
-  {{- range $extraConfig := .extraConfigs }}
-  - kind: {{ $extraConfig.kind }}
-    name: {{ $extraConfig.name }}
-    namespace: {{ $extraConfig.namespace }}
+  {{- range . }}
+  - name: {{ .name }}
+    namespace: {{ .namespace }}
+    {{- with .kind }}
+    kind: {{ . }}
+    {{- end }}
+    {{- with .priority }}
+    priority: {{ . }}
+    {{- end }}
   {{- end }}
   {{- end }}
   {{- if .userConfig }}

--- a/helm/service-mesh-bundle/values.schema.json
+++ b/helm/service-mesh-bundle/values.schema.json
@@ -28,16 +28,66 @@
                             "type": "boolean"
                         },
                         "extraConfigs": {
-                            "type": "array"
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "kind": {
+                                        "type": "string",
+                                        "pattern": "^(ConfigMap|Secret)$"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "type": "string"
+                                    },
+                                    "priority": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": ["name", "namespace"],
+                                "additionalProperties": false
+                            }
                         },
                         "namespace": {
                             "type": "string"
                         },
                         "namespaceConfig": {
-                            "type": "object"
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "labels": {
+                                    "type": "object"
+                                }
+                            },
+                            "additionalProperties": false
                         },
                         "userConfig": {
-                            "type": "object"
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "object",
+                                    "properties": {
+                                        "values": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "secret": {
+                                    "type": "object",
+                                    "properties": {
+                                        "values": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
                         },
                         "version": {
                             "type": "string"

--- a/helm/service-mesh-bundle/values.schema.json
+++ b/helm/service-mesh-bundle/values.schema.json
@@ -5,9 +5,13 @@
         "apps": {
             "type": "object",
             "properties": {
-                "linkerd2-cni": {
+                "linkerd-control-plane": {
+                    "id": "appSchema",
                     "type": "object",
                     "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
                         "appName": {
                             "type": "string"
                         },
@@ -15,6 +19,9 @@
                             "type": "string"
                         },
                         "chartName": {
+                            "type": "string"
+                        },
+                        "dependsOn": {
                             "type": "string"
                         },
                         "enabled": {
@@ -36,11 +43,26 @@
                             "type": "string"
                         }
                     }
+                },
+                "linkerd-multicluster-link": {
+                    "$ref": "appSchema"
+                },
+                "linkerd-multicluster": {
+                    "$ref": "appSchema"
+                },
+                "linkerd-viz": {
+                    "$ref": "appSchema"
+                },
+                "linkerd2-cni": {
+                    "$ref": "appSchema"
                 }
             }
         },
         "clusterID": {
             "type": "string"
+        },
+        "clusterValues": {
+            "type": "boolean"
         },
         "organization": {
             "type": "string"

--- a/helm/service-mesh-bundle/values.yaml
+++ b/helm/service-mesh-bundle/values.yaml
@@ -24,8 +24,7 @@ apps:
     extraConfigs: []
   linkerd-control-plane:
     appName: linkerd-control-plane
-    annotations:
-      app-operator.giantswarm.io/depends-on: linkerd2-cni
+    annotations: {}
     chartName: linkerd-control-plane
     catalog: giantswarm
     enabled: true
@@ -42,10 +41,10 @@ apps:
     version: 1.3.1
     userConfig: {}
     extraConfigs: []
+    dependsOn: linkerd2-cni
   linkerd-viz:
     appName: linkerd-viz
-    annotations:
-      app-operator.giantswarm.io/depends-on: linkerd-control-plane
+    annotations: {}
     chartName: linkerd-viz
     catalog: giantswarm
     enabled: true
@@ -58,6 +57,7 @@ apps:
     version: 1.5.0
     userConfig: {}
     extraConfigs: []
+    dependsOn: linkerd-control-plane
   linkerd-multicluster:
     appName: linkerd-multicluster
     annotations:
@@ -74,10 +74,10 @@ apps:
     version: 0.11.1
     userConfig: {}
     extraConfigs: []
+    dependsOn: linkerd-control-plane
   linkerd-multicluster-link:
     appName: linkerd-multicluster-link
-    annotations:
-      app-operator.giantswarm.io/depends-on: linkerd-multicluster
+    annotations: {}
     chartName: linkerd-multicluster-link
     catalog: giantswarm
     enabled: false
@@ -90,3 +90,4 @@ apps:
     version: 0.11.1
     userConfig: {}
     extraConfigs: []
+    dependsOn: linkerd-multicluster


### PR DESCRIPTION
This PR changes how App CR dependencies are specified to make it work on CAPI due to App CR names being different.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
